### PR TITLE
Added swiftGuard, Anti-forensic macOS Tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Curated list of awesome **free** (mostly open source) forensic analysis tools an
 - [macMRUParser](https://github.com/mac4n6/macMRU-Parser) - Python script to parse the Most Recently Used (MRU) plist files on macOS into a more human friendly format
 - [OSXAuditor](https://github.com/jipegit/OSXAuditor)
 - [OSX Collect](https://github.com/Yelp/osxcollector)
+- [swiftGuard](https://github.com/Lennolium/swiftGuard) - Anti-forensic macOS application designed to safeguard your system/server by monitoring USB ports for unauthorized access.
 
 ### Mobile Forensics
 


### PR DESCRIPTION
I added the macOS OpSec-enhancing/Anti-Forensic Application 'swiftGuard' to the category 'OS X Forensics'. If you think it would fit somewhere else, please feel free to edit.

It's a lightweight tool that safeguards your systems USB ports for any unauthorized access and initiates a shutdown or hibernation in case of threat detection.

[swiftGuard on Github](https://github.com/Lennolium/swiftGuard)


>__Disclaimer:__
>I'm an computer science student and developed this app by myself. I did not want to offensively spam/advertise my work here. _I really think_, it would improve this curated list and help others. 

>__Guidelines:__
>- [x] Lists within each section are alphabetized
>- [x] Add sections if necessary, use existing sections if possible
>- [x] Clear, concise descriptions for each link, followed by a period
>- [x] Use the following format: `[Item Name](homepage link) - Description.`
>- [x] No duplication of tools, put them where they make the most sense
>- [x] Prefer quality over quantity, only submit awesome stuff
>- [x] By submitting a pull request, you agree to release your submission under
  the [LICENSE](LICENSE)
