### PR TITLE
Add SQLite analysis tools to Mobile Forensics

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,12 +191,12 @@ Curated list of awesome **free** (mostly open source) forensic analysis tools an
 - [ALEAPP](https://github.com/abrignoni/ALEAPP) - An Android Logs Events and Protobuf Parser
 - [ArtEx](https://www.doubleblak.com/index.php) - Artifact Examiner for iOS Full File System extractions
 - [DB Browser for SQLite](https://sqlitebrowser.org/) - Lightweight GUI to inspect and query the SQLite databases that store key iOS/Android artifacts (e.g., sms.db, CallHistory.storedata, Safari/History.db, WhatsApp)
-- [SQLite Forensics Explorer](https://sqliteforensictoolkit.com/) - Investigative tool designed to show every single byte of an SQLite database or WAL file along with its decoded data.
 - [iLEAPP](https://github.com/abrignoni/iLEAPP) - An iOS Logs, Events, And Plists Parser
 - [iOS Frequent Locations Dumper](https://github.com/mac4n6/iOS-Frequent-Locations-Dumper) - Dump the contents of the StateModel#.archive files located in /private/var/mobile/Library/Caches/com.apple.routined/
 - [MEAT](https://github.com/jfarley248/MEAT) - Perform different kinds of acquisitions on iOS devices
 - [MobSF](https://github.com/MobSF/Mobile-Security-Framework-MobSF) - An automated, all-in-one mobile application (Android/iOS/Windows) pen-testing, malware analysis and security assessment framework capable of performing static and dynamic analysis.
 - [OpenBackupExtractor](https://github.com/vgmoose/OpenBackupExtractor) - An app for extracting data from iPhone and iPad backups.
+- [SQLite Forensics Explorer](https://sqliteforensictoolkit.com/) - Investigative tool designed to show every single byte of an SQLite database or WAL file along with its decoded data.
 
 
 ### Docker Forensics


### PR DESCRIPTION
Adds two SQLite tools commonly used to inspect iOS/Android database artifacts (sms.db, CallHistory.storedata, Safari History, etc.)