### PR TITLE
Add Wayback-Archive to Internet Artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,7 @@ Curated list of awesome **free** (mostly open source) forensic analysis tools an
 - [hindsight](https://github.com/obsidianforensics/hindsight) - Internet history forensics for Google Chrome/Chromium
 - [IE10Analyzer](https://github.com/moaistory/IE10Analyzer) - This tool can parse normal records and recover deleted records in WebCacheV01.dat.
 - [unfurl](https://github.com/obsidianforensics/unfurl) - Extract and visualize data from URLs
+- [Wayback-Archive](https://github.com/GeiserX/Wayback-Archive) - Download complete websites from the Wayback Machine with full asset preservation for offline viewing. Useful for forensic recovery of historical website states as evidence
 - [WinSearchDBAnalyzer](https://github.com/moaistory/WinSearchDBAnalyzer) - This tool can parse normal records and recover deleted records in Windows.edb.
 
 ### Timeline Analysis

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Curated list of awesome **free** (mostly open source) forensic analysis tools an
 - [hindsight](https://github.com/obsidianforensics/hindsight) - Internet history forensics for Google Chrome/Chromium
 - [IE10Analyzer](https://github.com/moaistory/IE10Analyzer) - This tool can parse normal records and recover deleted records in WebCacheV01.dat.
 - [unfurl](https://github.com/obsidianforensics/unfurl) - Extract and visualize data from URLs
-- [Wayback-Archive](https://github.com/GeiserX/Wayback-Archive) - Download complete websites from the Wayback Machine with full asset preservation for offline viewing. Useful for forensic recovery of historical website states as evidence
+- [Wayback-Archive](https://github.com/GeiserX/Wayback-Archive) - Download complete websites from the Wayback Machine with full asset preservation for offline viewing.
 - [WinSearchDBAnalyzer](https://github.com/moaistory/WinSearchDBAnalyzer) - This tool can parse normal records and recover deleted records in Windows.edb.
 
 ### Timeline Analysis


### PR DESCRIPTION
## Summary

- Adds [Wayback-Archive](https://github.com/GeiserX/Wayback-Archive) to the **Internet Artifacts** section
- Wayback-Archive is a Python tool (GPL-3.0) that downloads complete websites from the Wayback Machine with full asset preservation for offline viewing
- Useful for forensic recovery of historical website states as evidence (e.g., preserving web content that may have been altered or removed)
- Entry placed in alphabetical order within the section