### PR TITLE
Add StegoForge to steganography tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,9 +261,9 @@ Curated list of awesome **free** (mostly open source) forensic analysis tools an
 - [questio](https://github.com/abcreativ/questio) - Forensic PDF auditor CLI that detects edited or tampered PDFs via font session tracking, revision history mapping, and producer metadata analysis. Local-first, no uploads.
 
 ### Steganography
-- [StegoForge](https://github.com/Nour833/StegoForge) - Zero-dependency CLI/TUI engine for hiding and extracting encrypted payloads using offline AI forensics.
 - [Sonicvisualizer](https://www.sonicvisualiser.org)
 - [Steghide](https://github.com/StegHigh/steghide) - is a steganography program that hides data in various kinds of image and audio files
+- [StegoForge](https://github.com/Nour833/StegoForge) - Zero-dependency CLI/TUI engine for hiding and extracting encrypted payloads using offline AI forensics.
 - [Wavsteg](https://github.com/samolds/wavsteg) - is a steganography program that hides data in various kinds of image and audio files
 - [Zsteg](https://github.com/zed-0xff/zsteg) - A steganographic coder for WAV files
 

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ Curated list of awesome **free** (mostly open source) forensic analysis tools an
 - [questio](https://github.com/abcreativ/questio) - Forensic PDF auditor CLI that detects edited or tampered PDFs via font session tracking, revision history mapping, and producer metadata analysis. Local-first, no uploads.
 
 ### Steganography
-
+- [StegoForge](https://github.com/Nour833/StegoForge) - Zero-dependency CLI/TUI engine for hiding and extracting encrypted payloads using offline AI forensics.
 - [Sonicvisualizer](https://www.sonicvisualiser.org)
 - [Steghide](https://github.com/StegHigh/steghide) - is a steganography program that hides data in various kinds of image and audio files
 - [Wavsteg](https://github.com/samolds/wavsteg) - is a steganography program that hides data in various kinds of image and audio files


### PR DESCRIPTION
Hi there!

I would like to submit StegoForge for the Steganography section. It is an open-source (MIT) digital forensics framework I recently built.

It provides a zero-dependency executable that unifies offensive injection (JPEG DCT, MP4 motion vectors) with defensive extraction (RS Analysis, Chi-square, and offline HuggingFace ML). Because it is packaged as a standalone binary with a TUI, it's highly suited for air-gapped forensic labs and CTFs without requiring Python dependency management. Also it has amazing features like social-media-compression proof image ...

Let me know if you need me to adjust the description or formatting. Thanks for maintaining this awesome list!