### PR TITLE
Add Hypoxia to Acquisition section

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Curated list of awesome **free** (mostly open source) forensic analysis tools an
 - [ForensicMiner](https://github.com/securityjoes/ForensicMiner) - A PowerShell-based DFIR automation tool, for artifact and evidence collection on Windows machines.
 - [Fuji](https://github.com/Lazza/Fuji/) - MacOS forensic acquisition made simple. It creates full file system copies or targeted collection of Mac computers.
 - [Hashment](https://github.com/hashment/yaffs2-forensic-tool) - Python forensic tool to analyze, dump, and recover deleted files from YAFFS2 partitions.
+- [Hypoxia](https://github.com/xinitd/hypoxia) - Cross-platform CLI tool for targeted file collection with SHA-256 manifest, chain-of-custody log, and checkpoint/resume support.
 - [LiME](https://github.com/jtsylve/LiME) - Loadable Kernel Module (LKM), which allows the acquisition of volatile memory from Linux and Linux-based devices, formerly called DMD
 - [Magnet RAM Capture / DumpIt](https://www.magnetforensics.com/resources/magnet-dumpit-for-windows/) - A free imaging tool designed to capture the physical memory
 - [SPECTR3](https://github.com/alpine-sec/SPECTR3) - Acquire, triage and investigate remote evidence via portable iSCSI readonly access


### PR DESCRIPTION
Adding Hypoxia, an open-source CLI tool for targeted forensic file collection.

Key features that fit the Acquisition section:
- Pure Python, zero dependencies, runs on Linux/macOS/Windows
- Filters by file extension, date range, and size
- Generates SHA-256 forensic manifest with integrity checksum
- Append-only chain-of-custody log
- Checkpoint/resume support for interrupted collections (useful when working with failing media)

Repository: https://github.com/xinitd/hypoxia

I've followed the contribution guidelines:
- Alphabetized within the Acquisition section
- Used the [Item Name](link) - Description. format
- Added between Hashment and LiME