### PR TITLE
Add RDPuzzle - neural-assisted RDP bitmap cache reconstruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Curated list of awesome **free** (mostly open source) forensic analysis tools an
 - [LastActivityView](https://www.nirsoft.net/utils/computer_activity_view.html) - LastActivityView by Nirsoftis a tool for Windows operating system that collects information from various sources on a running system, and displays a log of actions made by the user and events occurred on this computer. 
 - [LogonTracer](https://github.com/JPCERTCC/LogonTracer) - Investigate malicious Windows logon by visualizing and analyzing Windows event log
 - :zzz: [python-evt](https://github.com/williballenthin/python-evt) - Pure Python parser for classic Windows Event Log files (.evt)
+- [RDPuzzle](https://github.com/BZDaniel/RDPuzzle) - Browser-based neural-assisted tool for reconstructing RDP bitmap cache fragments
 - [RegRipper3.0](https://github.com/keydet89/RegRipper3.0) - RegRipper is an open source Perl tool for parsing the Registry and presenting it for analysis
 - [RegRippy](https://github.com/airbus-cert/regrippy) - A framework for reading and extracting useful forensics data from Windows registry hives
 


### PR DESCRIPTION
Adds [RDPuzzle](https://github.com/BZDaniel/RDPuzzle) to the Windows Artifacts section.

RDPuzzle is a self-contained browser tool that reconstructs RDP bitmap cache fragments (BMC/BIN) into readable screenshots using neural edge-matching, auto-stitching, and OCR, all running locally client-side.

The ONNX models are self-trained on real RDP cache data.