### PR TITLE
Add Open Investigator

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Curated list of awesome **free** (mostly open source) forensic analysis tools an
 - [IntelMQ](https://github.com/certtools/intelmq) - IntelMQ collects and processes security feeds
 - [Kuiper](https://github.com/DFIRKuiper/Kuiper) - Digital Investigation Platform
 - [Laika BOSS](https://github.com/lmco/laikaboss) - Laika is an object scanner and intrusion detection system
+- [Open Investigator](https://github.com/SEc-123/open-investigator) - AI-assisted local Linux and Windows host investigation with sealed read-only tools and auditable incident reports.
 - [OpenRelik](https://openrelik.org/) - Forensic platform to store file artifacts and run workflows
 - :zzz: [PowerForensics](https://github.com/Invoke-IR/PowerForensics) - PowerForensics is a framework for live disk forensic analysis
 - :star: [The Sleuth Kit](https://github.com/sleuthkit/sleuthkit) - Tools for low level forensic analysis


### PR DESCRIPTION
Adds Open Investigator to the Frameworks section as an AI-assisted local host investigation tool.

Maintainer disclosure: I maintain Open Investigator. I added a single entry and kept the description focused on what it does: sealed read-only host evidence collection and auditable incident reports.